### PR TITLE
Give GCP access to Sean

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ resource "google_project" "fully_managed_project" {
 }
 
 resource "google_project_iam_binding" "project_owners" {
-  for_each = var.fully_managed_projects
+  for_each = toset(concat(keys(var.fully_managed_projects), var.managed_projects))
 
   project = each.key
   # FIXME: Investigate if roles/editor is enough?

--- a/projects.tfvars
+++ b/projects.tfvars
@@ -5,5 +5,5 @@ fully_managed_projects = {
 }
 
 managed_projects = [
-    # "cb-1003-1696"
+    "cb-1003-1696"
 ]

--- a/variables.tf
+++ b/variables.tf
@@ -25,6 +25,7 @@ variable "project_owners" {
     "user:georgianaelena@2i2c.org",
     "user:choldgraf@2i2c.org",
     "user:damianavila@2i2c.org",
-    "user:erik@2i2c.org"
+    "user:erik@2i2c.org",
+    "user:sean.smorris@berkeley.edu"
   ]
 }


### PR DESCRIPTION
Ref https://github.com/2i2c-org/team-compass/issues/76
     
Requires https://github.com/2i2c-org/org-ops/pull/1

Terraform plan is:

```
─$ terraform plan -var-file projects.tfvars
Acquiring state lock. This may take a few moments...
google_project.fully_managed_project["two-eye-two-see"]: Refreshing state... [id=projects/two-eye-two-see]
google_project_iam_binding.project_owners["two-eye-two-see"]: Refreshing state... [id=two-eye-two-see/roles/owner]
google_storage_bucket.managed_terraform_state: Refreshing state... [id=two-eye-two-see-org-terraform-state]

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # google_project_iam_binding.project_owners["cb-1003-1696"] will be created
  + resource "google_project_iam_binding" "project_owners" {
      + etag    = (known after apply)
      + id      = (known after apply)
      + members = [
          + "user:choldgraf@2i2c.org",
          + "user:damianavila@2i2c.org",
          + "user:erik@2i2c.org",
          + "user:georgianaelena@2i2c.org",
          + "user:sean.smorris@berkeley.edu",
          + "user:yuvipanda@2i2c.org",
        ]
      + project = "cb-1003-1696"
      + role    = "roles/owner"
    }

  # google_project_iam_binding.project_owners["two-eye-two-see"] will be updated in-place
  ~ resource "google_project_iam_binding" "project_owners" {
        id      = "two-eye-two-see/roles/owner"
      ~ members = [
          + "user:sean.smorris@berkeley.edu",
            # (5 unchanged elements hidden)
        ]
        # (3 unchanged attributes hidden)
    }

Plan: 1 to add, 1 to change, 0 to destroy.

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.

Releasing state lock. This may take a few moments...
```

Note that this includes the changes for #1 